### PR TITLE
Fix year range queries

### DIFF
--- a/api/cloudant_query.md
+++ b/api/cloudant_query.md
@@ -1024,9 +1024,7 @@ _Example of using the $nor operator:_
 {
 	"selector": {
 		"year": {
-			"$gte": 1900
-		},
-		"year": {
+			"$gte": 1900,
 			"$lte": 1910
 		},
 		"$nor": [
@@ -1054,9 +1052,7 @@ _Example of using the $not operator:_
 {
 	"selector": {
 		"year": {
-			"$gte": 1900
-		},
-		"year": {
+			"$gte": 1900,
 			"$lte": 1903
 		},
 		"$not": {


### PR DESCRIPTION
A JavaScript object can't have two keys called "year", the < and > operators must be in the same sub-object.